### PR TITLE
Remove profile images styling (height=100%)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -141,7 +141,6 @@ nav.nav-white ul li a:hover{
 
 .img_res{
   max-height: 250px;
-  height: 100%;
 }
 
 .grey{


### PR DESCRIPTION
This fixes a styling mishap where the profile images are all contorted.
Removing 'height: 100%' keeps the face images in proper aspect ratio, and and the same size.
