### PR TITLE
fixed css for links in /finances

### DIFF
--- a/finances/index.html
+++ b/finances/index.html
@@ -10,7 +10,7 @@
   span.tt {
     font-family: "Courier", monospace;
   }
-  .activities-content p a, li a {
+  .activities-content p a, .activities-content li a {
     text-decoration: underline;
   }
   </style>


### PR DESCRIPTION
links in footer now correctly show `text-decoration: none`