### PR TITLE
Prevent links to certain pages from showing up in the search engine result

### DIFF
--- a/browser-extension/index.html
+++ b/browser-extension/index.html
@@ -5,6 +5,7 @@
 
     <!--# include file="/includes/head.html" -->
 
+    <meta name="robots" content="noindex">
     <link href="/includes/stylesheets/slideshow.css" media="screen, projection" rel="stylesheet" type="text/css" />
 </head>
 

--- a/browser-extension/index.html
+++ b/browser-extension/index.html
@@ -5,7 +5,7 @@
 
     <!--# include file="/includes/head.html" -->
 
-    <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex" />
     <link href="/includes/stylesheets/slideshow.css" media="screen, projection" rel="stylesheet" type="text/css" />
 </head>
 

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -10,11 +10,6 @@
                 Blog
             </a>
         </li>
-        <!-- <li>
-            <a href="//forums.okturtles.org">
-                Forums
-            </a>
-        </li> -->
         <li>
             <a href="/donate">
                 <i class="fas fa-heart" style="color:darkred"></i> Donate
@@ -25,11 +20,6 @@
                 Team
             </a>
         </li>
-<!--         <li>
-            <a href="#contactEmail" class="fancybox">
-                Contact
-            </a>
-        </li> -->
     </ul>
     <div class="clearfix"></div>
     <ul class="social-icons">


### PR DESCRIPTION
partial work for #60 

This PR is about preventing `/browser-extension` page and 'https://forums.okturtles.org' from showing up as Sitelinks of the search engine result.

1.
Firstly, `/browser-extension` page is an internal page of `okturtles.org` website and in this case, specifying [`noindex`](https://developers.google.com/search/docs/crawling-indexing/block-indexing) `<meta />` tag is a recommended way to block it from getting indexed by search engines.

2.  'https://forums.okturtles.org' is not an internal page that belongs to `okturtles.org` website, so `noindex` cannot be of use in this case. However, Judging by the Sitelinks screenshot below,

<img src='https://github.com/okTurtles/okturtles.com/assets/17641213/311f38fa-1195-4415-a547-f1e02f389cc5' width='520'>

all four sitelinks there(`Forums`, `Blog`, `Donate`, `Team`) are actually what the website's footer contains as the link content in the source-code.

<img src='https://github.com/okTurtles/okturtles.com/assets/17641213/15accc3b-758a-4884-9772-474f11a748d8' width='430'>

So we can logically think that `footer.html` is where the search engine's crawler gets them. therefore, I decided to remove the `Forum` link from the source-code rather than commenting it out.
