### PR TITLE
#60 - Try promoting certain page / external-links for search engine crawlers

### DIFF
--- a/includes/footer.html
+++ b/includes/footer.html
@@ -5,6 +5,8 @@
                 Home
             </a>
         </li>
+        <!-- Explanation for these commented out links: https://github.com/okTurtles/okturtles.com/pull/64 -->
+
         <!-- <li>
             <a href="https://groupincome.org">
                 Group Income

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -5,6 +5,16 @@
                 Home
             </a>
         </li>
+        <!-- <li>
+            <a href="https://groupincome.org">
+                Group Income
+            </a>
+        </li> -->
+        <!-- <li>
+            <a href="https://shelterprotocol.net">
+                Shelter protocol
+            </a>
+        </li> -->
         <li>
             <a href="//blog.okturtles.org">
                 Blog

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
 
+Sitemap: https://okturtles.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,8 +18,4 @@
   <url>
     <loc>https://okturtles.org/team</loc>
   </url>
-
-  <url>
-    <loc>https://okturtles.org/finances</loc>
-  </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://okturtles.org/</loc>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://okturtles.org/dpki</loc>
+  </url>
+
+  <url>
+    <loc>https://okturtles.org/donate</loc>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://okturtles.org/team</loc>
+  </url>
+
+  <url>
+    <loc>https://okturtles.org/finances</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
closes #60 

The aim of this chunk of work is to increase the possibility that certain page / links we prefer show up as website's [sitelinks ](https://developers.google.com/search/docs/appearance/sitelinks) in the search result, which are

- Shelter Protocol
- Group Income
- Blog
- Donation page

---
@taoeffect 

[ 1. ]
'Donation page' here is an internal page of the website and in this case we can use the `<priority></priority>` field in `sitemap.xml` as **a hint** to search algorithm that we consider it more important than other pages.

[ 2. ]
The other three in the list are external links and there is no direct way to promote them as sitelinks other than making sure that the hyperlinks being used for them in the source-code comply with best practices recommended by [this google article](https://developers.google.com/search/docs/crawling-indexing/links-crawlable). It appears that all of them are currently written in a 'crawlable' way according to the best practices.
(e.g. `<a>` tags have descriptive texts as the content, `<img />` inside an `<a></a>` tag has `alt` property that describes the hyperlink)

However, as mentioned in [this previous PR](https://github.com/okTurtles/okturtles.com/pull/63) too, we have a logical clue that the sitelinks were crawled & created from the website's `footer.html`. So I decided to exploit it as a trick here and added some commented out external-links there, in an attempt to make the search engine crawl them.

I hope it sounds good and let me know if you think otherwise.