### PR TITLE
#89 - Video progress bar is too narrow on mobile-size screen

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -94,7 +94,7 @@ import VideoPlayer from '@/components/VideoPlayer.vue'
 	<!-- https is broken -->
 	<section class="https-is-broken">
 		<div class="container">
-      <div class="vidplayer-container">
+      <div class="vidplayer-container has-medium-box-shadow">
         <VideoPlayer client:only="vue"
           src='/videos/group_income_ending_big_tech_control.mp4'
           mimeType='video/mp4'
@@ -419,6 +419,11 @@ import VideoPlayer from '@/components/VideoPlayer.vue'
 	position: relative;
 	display: block;
 	width: 100%;
+
+  @include until ($tablet) {
+    width: calc(100% + 2rem);
+    margin-left: -1rem;
+  }
 
 	iframe {
 		display: block;

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -10,3 +10,7 @@ $dark-green: #0C6130;
 $blue: #1479DE;
 $blue_1: #105EAA;
 $danger: #c62828;
+
+$drop-shadow_shallow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+$drop-shadow_medium: rgba(50, 50, 93, 0.175) 0px 18px 36px -7px, rgba(0, 0, 0, 0.215) 0px 10px 21px -11px;
+$drop-shadow_deep: rgba(50, 50, 93, 0.2) 0px 30px 60px -12px, rgba(0, 0, 0, 0.25) 0px 18px 36px -18px;

--- a/src/styles/_page_common.scss
+++ b/src/styles/_page_common.scss
@@ -11,3 +11,15 @@
 	background-color: $white;
 	@include side-padding;
 }
+
+.has-deep-box-shadow {
+  box-shadow: $drop-shadow_deep;
+}
+
+.has-medium-box-shadow {
+  box-shadow: $drop-shadow_medium;
+}
+
+.has-shallow-box-shadow {
+  box-shadow: $drop-shadow_shallow;
+}

--- a/src/styles/plyr/_plyr_override.scss
+++ b/src/styles/plyr/_plyr_override.scss
@@ -1,6 +1,8 @@
 @use "../variables" as *;
 @use "./plyr_default";
 
+$phone_narrow: 430px;
+
 .plyr_override {
   // To override default colors of the player, refer to this css color variable table:
   // https://www.npmjs.com/package/plyr#customizing-the-css
@@ -11,5 +13,26 @@
 
   .plyr {
     aspect-ratio: inherit;
+  }
+
+  // NOTE: When the screen size is narrow, there is an issue where the play/resume button and the progress-bar UI becomes too small
+  //       (Even smaller than the volume-control UI). To get more space for the play progess bar, we hide some buttons that are not absolutely essential
+  //       when compared to others.
+  //       (eg.) Essential -  play button / progress-bar / mute button / volume-control / full-screen button.
+  //             Not absolutely essential - play-speed control menu / PIP (picture-in-picture) button.
+  .plyr__controls {
+    @include until($phone_narrow) {
+      .plyr__controls__item[data-plyr="pip"],
+      .plyr__controls__item.plyr__menu {
+        display: none;
+      }
+    }
+
+    @include until ($tablet) {
+      input[data-plyr="volume"] {
+        min-width: 0px;
+        max-width: 60px;
+      }
+    }
   }
 }


### PR DESCRIPTION
closes #89 

Also made sure that the video takes the full screen-width on narrow size screen.

<img src='https://github.com/user-attachments/assets/db133b00-8a9d-495d-b338-363710b9e4b4' width='340'>