### PR TITLE
#100 Portrait orientation on video player when viewed in full-screen mode on mobile browsers (Android)

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { useTemplateRef, ref, onMounted } from 'vue'
+import { useTemplateRef, ref, onMounted, onBeforeUnmount } from 'vue'
 interface ComponentProps {
   src: string,
   mimeType: string,
@@ -18,8 +18,20 @@ const props = defineProps<ComponentProps>()
 
 const videoEl = useTemplateRef('video-el')
 const player = ref<any>(null)
+const isPhone = ref<boolean>(false)
+let isPhoneMatchMedia: any = null
 
 // methods
+const adjustDeviceOrientation = (toLandscape: boolean = false) => {
+  const orientationHandle = screen?.orientation as any
+  if (isPhone.value && orientationHandle && 'lock' in orientationHandle) {
+    const valTo = toLandscape ? 'landscape' : 'any'
+    orientationHandle.lock(valTo).catch((err: any) => {
+      console.error('Failed to lock screen orientation', err)
+    })
+  }
+}
+
 const initPlayer = () => {
   const opts = {
     // Documentation for plyr options: https://www.npmjs.com/package/plyr#options
@@ -33,10 +45,30 @@ const initPlayer = () => {
   }
 
   player.value = new Plyr(videoEl.value as HTMLElement, opts)
+
+  // Event listeners
+  player.value.on('enterfullscreen', () => {
+    adjustDeviceOrientation(true)
+  })
+  player.value.on('exitfullscreen', () => {
+    adjustDeviceOrientation(false)
+  })
 }
 
 onMounted(() => {
   initPlayer()
+
+  isPhoneMatchMedia = matchMedia('(hover: none) and (pointer: coarse) and (max-width: 768px)')
+  isPhoneMatchMedia.onchange = () => {
+    isPhone.value = isPhoneMatchMedia.matches
+  }
+  isPhone.value = isPhoneMatchMedia.matches
+})
+
+onBeforeUnmount(() => {
+  if (isPhoneMatchMedia) {
+    isPhoneMatchMedia.onchange = null
+  }
 })
 </script>
 


### PR DESCRIPTION
work on #100 

When full-screen mode is entered, this is how the video player currently looks:

<img width="320" src="https://github.com/user-attachments/assets/b575573b-6af6-43ef-8f98-bfefe7cef10b" />

Using `lock()` method of `screen.orientation` browser API(in `Android`, iOS browsers apparently doesn't allow changing screen orientation programatically), we can change the screen orientation to `portrait` mode (confirmed this works on chrome, brave, samsung internet of my android phone):

https://github.com/user-attachments/assets/7e6cde7e-09da-4c59-9256-ae63470d7344
